### PR TITLE
Add job autocleanup

### DIFF
--- a/pycalrissian/job.py
+++ b/pycalrissian/job.py
@@ -45,6 +45,7 @@ class CalrissianJob:
         keep_pods: bool = False,
         backoff_limit: int = 2,
         tool_logs: bool = False,
+        self.ttl_seconds_after_finished = 0
     ):
 
         self.cwl = cwl
@@ -63,7 +64,8 @@ class CalrissianJob:
         self.keep_pods = keep_pods
         self.backoff_limit = backoff_limit
         self.volume_calrissian_wdir = "volume-calrissian-wdir"
-        self.tool_logs = tool_logs
+        self.tool_logs = tool_logs,
+        self.ttl_seconds_after_finished = ttl_seconds_after_finished
 
         if self.security_context is None:
             logger.info(
@@ -316,7 +318,7 @@ class CalrissianJob:
         return pod_template
 
     @staticmethod
-    def create_job(name, pod_template, namespace, backoff_limit=4, ttl_seconds_after_finished=0):
+    def create_job(name, pod_template, namespace, backoff_limit=4):
         metadata = client.V1ObjectMeta(
             name=name, labels={"job_name": name}, namespace=namespace
         )
@@ -328,7 +330,7 @@ class CalrissianJob:
             spec=client.V1JobSpec(
                 backoff_limit=backoff_limit,
                 template=pod_template,
-                ttl_seconds_after_finished=ttl_seconds_after_finished
+                ttl_seconds_after_finished=self.ttl_seconds_after_finished
             ),
         )
 

--- a/pycalrissian/job.py
+++ b/pycalrissian/job.py
@@ -316,7 +316,7 @@ class CalrissianJob:
         return pod_template
 
     @staticmethod
-    def create_job(name, pod_template, namespace, backoff_limit=4):
+    def create_job(name, pod_template, namespace, backoff_limit=4, ttl_seconds_after_finished=0):
         metadata = client.V1ObjectMeta(
             name=name, labels={"job_name": name}, namespace=namespace
         )
@@ -328,6 +328,7 @@ class CalrissianJob:
             spec=client.V1JobSpec(
                 backoff_limit=backoff_limit,
                 template=pod_template,
+                ttl_seconds_after_finished=ttl_seconds_after_finished
             ),
         )
 


### PR DESCRIPTION
In our use case we need to be able not to remove the namespace but only the completed pods. So adding the ttl_seconds_after_finished (using the default 0 won't change current behaviour) in the ZooCalrissianRunner will allow us to solve our use case. This is the Job documentation:

https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1JobSpec.md

thanks
f.