### PR TITLE
Enable Dask support from pycalrissian

### DIFF
--- a/pycalrissian/context.py
+++ b/pycalrissian/context.py
@@ -26,6 +26,7 @@ class CalrissianContext:
         kubeconfig_file: TextIO = None,
         labels: Dict = None,
         annotations: Dict = None,
+        service_account: str = None,
     ):
         """Creates a CalrissianContext object
 
@@ -62,7 +63,7 @@ class CalrissianContext:
         self.annotations = annotations
 
         self.existing_namespace = False
-        self.service_account = None
+        self.service_account = service_account
 
     @classmethod
     def from_existing_namespace(
@@ -140,10 +141,14 @@ class CalrissianContext:
 
             for key, value in roles.items():
                 logger.info(f"create role {key}")
+                # Add configmaps and secrets to pod-manager-role resources
+                resources = ["pods", "pods/log"]
+                if key == "pod-manager-role":
+                    resources.extend(["configmaps", "secrets"])
                 response = self.create_role(
                     name=key,
                     verbs=value["verbs"],
-                    resources=["pods", "pods/log"],
+                    resources=resources,
                     api_groups=["*"],
                 )
                 # print(type(response))

--- a/pycalrissian/job.py
+++ b/pycalrissian/job.py
@@ -45,7 +45,9 @@ class CalrissianJob:
         keep_pods: bool = False,
         backoff_limit: int = 2,
         tool_logs: bool = False,
-        ttl_seconds_after_finished: int = None
+        ttl_seconds_after_finished: int = None,
+        dask_gateway_url: str = None,
+        dask_script_configmap: str = None
     ):
 
         self.cwl = cwl
@@ -66,6 +68,8 @@ class CalrissianJob:
         self.volume_calrissian_wdir = "volume-calrissian-wdir"
         self.tool_logs = tool_logs
         self.ttl_seconds_after_finished = ttl_seconds_after_finished
+        self.dask_gateway_url = dask_gateway_url
+        self.dask_script_configmap = dask_script_configmap
 
         if runtime_context.service_account is not None:
             logger.info(f"using '{runtime_context.service_account}' service account selected from runtime context")
@@ -388,6 +392,12 @@ class CalrissianJob:
             args.extend(["--tool-logs-basepath", self.calrissian_base_path])
 
         args.extend(["--enable-ext"])
+
+        # Add Dask Gateway arguments if provided
+        if self.dask_gateway_url:
+            args.extend(["--dask-gateway-url", self.dask_gateway_url])
+        if self.dask_script_configmap:
+            args.extend(["--dask-script-configmap", self.dask_script_configmap])
 
         if self.cwl_entry_point is not None:
             args.extend(

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -105,7 +105,7 @@ class TestCalrissianContext(unittest.TestCase):
         response = session.create_role(
             name=role_name,
             verbs=roles["pod-manager-role"]["verbs"],
-            resources=["pods", "pods/log"],
+            resources=["pods", "pods/log", "configmaps", "secrets"],
             api_groups=["*"],
         )
 


### PR DESCRIPTION
This pull request introduces support for Dask Gateway workflows. The main changes include expanded role permissions for pod management, new support for Dask Gateway configuration in jobs, and improved handling of service accounts.

ref. https://github.com/EOEPCA/roadmap/issues/520